### PR TITLE
Accept optional DELETE_URL variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ pub struct Item {
     #[serde(alias = "sbom_id")]
     pub id: String,
 }
-async fn get_delete_list(url: String, token: String) -> ResponseData{
+async fn get_delete_list(url: &str, token: &str) -> ResponseData{
     let req_url: Url = Url::parse(&url).expect("Error parsing");
     let client = Client::builder().danger_accept_invalid_certs(true).build().expect("Failed");
     let response = client
@@ -38,12 +38,12 @@ async fn get_delete_list(url: String, token: String) -> ResponseData{
     tpares
 }
 
-async fn delete_resource(url:String, token: String, delete_list: ResponseData) {
+async fn delete_resource(url: &str, token: &str, delete_list: ResponseData) {
     println!("Deletion Started...");
     println!("Total number of records to be deleted: {}", delete_list.total);
     let mut responses = Vec::with_capacity(delete_list.total.try_into().unwrap());
     for item in delete_list.items {
-        let delete_url = format!("{}/{}",url, item.id);
+        let delete_url = format!("{}{}",url, item.id);
         let req_url: Url = Url::parse(&delete_url).expect("Error parsing");
         println!("Delete URL {}", &req_url);
         let client = Client::builder().danger_accept_invalid_certs(true).build().expect("Failed");
@@ -60,22 +60,31 @@ async fn delete_resource(url:String, token: String, delete_list: ResponseData) {
 
 #[tokio::main]
 async fn main() {
-    let api_url = match env::var("BASE_URL") { // Example https://server.apps.tpa.qe.net/api/v2/advisory
+    let list_url: String = match env::var("BASE_URL") { // Example https://server.apps.tpa.qe.net/api/v2/advisory
         Ok(url) => url,
         _ => panic!("ERROR: Specify BASE_URL env var (e.g. BASE_URL='http://localhost/api/v2/advisory')"),
     };
     let filter = match env::var("Q") { //?q=modified%3E1996-12-31T18%3A30%3A00.000Z%26modified%3C2024-12-30T18%3A30%3A00.000Z
-        Ok(query) => query,
+        Ok(query) => query.to_string(),
         _ => panic!("ERROR: Specify in Q env var the query part of url (e.g. Q='?q=modified...')"),
     };
     let token: String = match env::var("API_TOKEN") { //API Token
         Ok(token) => token,
         _ => panic!("ERROR: Specify authentication token for API (value for Bearer token, e.g. API_TOKEN=blah)"),
     };
+    // optional - can be used when base_url points to special query/endpoints (like analysis/component)
+    let delete_url: String = match env::var("DELETE_URL") { // Example https://server.apps.tpa.qe.net/api/v2/advisory/ (always include full url part including slash at the end)
+        Ok(url) => url, // custom delete url provided
+        _ => match list_url.chars().nth_back(0).unwrap() {
+            // when defaulting to base_url, ensure it ends with slash for appending Item.id after that
+            '/' => list_url.clone(),
+            _   => list_url.clone() + "/",
+        },
+    };
 
-    let get_url = format!("{}{}",api_url, filter);
-    let res = get_delete_list(get_url.to_string(), token.to_string()).await;
-    delete_resource(api_url.to_string(), token.to_string(), res).await;
+    let get_url = format!("{}{}", list_url, filter);
+    let res = get_delete_list(&get_url, &token).await;
+    delete_resource(&delete_url, &token, res).await;
 
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,9 @@ async fn main() {
         Ok(url) => url,
         _ => panic!("ERROR: Specify BASE_URL env var (e.g. BASE_URL='http://localhost/api/v2/advisory')"),
     };
-    let filter = match env::var("Q") { //q=modified%3E1996-12-31T18%3A30%3A00.000Z%26modified%3C2024-12-30T18%3A30%3A00.000Z
+    let filter = match env::var("Q") { //?q=modified%3E1996-12-31T18%3A30%3A00.000Z%26modified%3C2024-12-30T18%3A30%3A00.000Z
         Ok(query) => query,
-        _ => panic!("ERROR: Specify in Q env var the query part of url (e.g. Q='q=modified...')"),
+        _ => panic!("ERROR: Specify in Q env var the query part of url (e.g. Q='?q=modified...')"),
     };
     let token: String = match env::var("API_TOKEN") { //API Token
         Ok(token) => token,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ pub struct ResponseData {
 pub struct Item {
     #[serde(rename = "id")]
     #[serde(alias = "uuid")]
+    #[serde(alias = "sbom_id")]
     pub id: String,
 }
 async fn get_delete_list(url: String, token: String) -> ResponseData{


### PR DESCRIPTION
When list of Items is obtained from API endpoint (like analysis)
different from the one used for the deletion (like sbom),
it is necessary to use different URL for list from the one for deletion.

So optional DELETE_URL can be set.

To keep original behavior without it, default to BASE_URL,
but to also allow customized DELETE_URL
(e.g. with prefix `...sbom/urn:uuid:` for the Item.id),
append `/` only when using BASE_URL, not when customizing.

Side change:
- Functions should better accept borrowed &str instead of String,
  to avoid getting deeper in ownership issues.
- Fix Q vars description to include starting param delimiter `?`
- Add sbom_id to Item.id aliases (returned in analysis endpoint results)
